### PR TITLE
README.md file has a incorrect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ KEY = 'subscription key'  # Replace with a valid Subscription Key here.
 CF.Key.set(KEY)
 
 img_url = 'https://raw.githubusercontent.com/Microsoft/Cognitive-Face-Windows/master/Data/detection1.jpg'
-result = cf.face.detect(url)
+result = CF.face.detect(img_url)
 print result
 ```
 


### PR DESCRIPTION
```python
import cognitive_face as CF

KEY = 'subscription key'  # Replace with a valid Subscription Key here.
CF.Key.set(KEY)

img_url = 'https://raw.githubusercontent.com/Microsoft/Cognitive-Face-Windows/master/Data/detection1.jpg'
result = cf.face.detect(url)
print result
```
this sample named minimal usage is in README.md.

but this has a error. 

line 10, cf.face.detect(url) to CF.face.detect(img_url)

the result : 

```python
import cognitive_face as CF

KEY = 'subscription key'  # Replace with a valid Subscription Key here.
CF.Key.set(KEY)

img_url = 'https://raw.githubusercontent.com/Microsoft/Cognitive-Face-Windows/master/Data/detection1.jpg'
result = CF.face.detect(img_url)
print result
```