### PR TITLE
Implemented Regional API URL in config instead of hardcoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ import cognitive_face as CF
 KEY = 'subscription key'  # Replace with a valid Subscription Key here.
 CF.Key.set(KEY)
 
-REGION = 'westus'  # Replace with a valid region: westus, eastus2, westcentralus, westeurope, southeastasia
-CF.Region.set(REGION) # If not set, default will be 'westus'
+BASE_URL = 'https://westus.api.cognitive.microsoft.com/face/v1.0/'  # Replace with your regional Base URL
+CF.BaseUrl.set(BASE_URL)
 
 img_url = 'https://raw.githubusercontent.com/Microsoft/Cognitive-Face-Windows/master/Data/detection1.jpg'
 result = CF.face.detect(img_url)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ import cognitive_face as CF
 KEY = 'subscription key'  # Replace with a valid Subscription Key here.
 CF.Key.set(KEY)
 
+REGION = 'westus'  # Replace with a valid region: westus, eastus2, westcentralus, westeurope, southeastasia
+CF.Region.set(REGION) # If not set, default will be 'westus'
+
 img_url = 'https://raw.githubusercontent.com/Microsoft/Cognitive-Face-Windows/master/Data/detection1.jpg'
 result = CF.face.detect(img_url)
 print result

--- a/cognitive_face/__init__.py
+++ b/cognitive_face/__init__.py
@@ -12,3 +12,4 @@ from . import person_group
 from . import util
 from .util import CognitiveFaceException
 from .util import Key
+from .util import Region

--- a/cognitive_face/__init__.py
+++ b/cognitive_face/__init__.py
@@ -12,4 +12,4 @@ from . import person_group
 from . import util
 from .util import CognitiveFaceException
 from .util import Key
-from .util import Region
+from .util import BaseUrl

--- a/cognitive_face/tests/__init__.py
+++ b/cognitive_face/tests/__init__.py
@@ -23,11 +23,11 @@ def setUpModule():
     """Setup for the whole unitests.
 
     - Set Subscription Key.
-    - Set API Region.
+    - Set Base URL.
     - Setup needed data for unitests.
     """
     CF.Key.set(config.KEY)
-    CF.Region.set(config.REGION)
+    CF.BaseUrl.set(config.BASE_URL)
     util.DataStore.setup_person_group()
     util.DataStore.setup_face_list()
     util.DataStore.setup_face()

--- a/cognitive_face/tests/__init__.py
+++ b/cognitive_face/tests/__init__.py
@@ -23,9 +23,11 @@ def setUpModule():
     """Setup for the whole unitests.
 
     - Set Subscription Key.
+    - Set API Region.
     - Setup needed data for unitests.
     """
     CF.Key.set(config.KEY)
+    CF.Region.set(config.REGION)
     util.DataStore.setup_person_group()
     util.DataStore.setup_face_list()
     util.DataStore.setup_face()

--- a/cognitive_face/tests/config.sample.py
+++ b/cognitive_face/tests/config.sample.py
@@ -11,8 +11,9 @@ Description: unittest configuration for Python SDK of the Cognitive Face API.
 # Subscription Key for calling the Cognitive Face API.
 KEY = ''
 
-# Region for calling the Cognitive Face API.
-REGION = ''
+# Base URL for calling the Cognitive Face API.
+# default is 'https://westus.api.cognitive.microsoft.com/face/v1.0/'
+BASE_URL = ''
 
 # Time (in seconds) for sleep between each call to avoid exceeding quota.
 # Default to 3 as free subscription have limit of 20 calls per minute.

--- a/cognitive_face/tests/config.sample.py
+++ b/cognitive_face/tests/config.sample.py
@@ -11,6 +11,9 @@ Description: unittest configuration for Python SDK of the Cognitive Face API.
 # Subscription Key for calling the Cognitive Face API.
 KEY = ''
 
+# Region for calling the Cognitive Face API.
+REGION = ''
+
 # Time (in seconds) for sleep between each call to avoid exceeding quota.
 # Default to 3 as free subscription have limit of 20 calls per minute.
 TIME_SLEEP = 3

--- a/cognitive_face/util.py
+++ b/cognitive_face/util.py
@@ -11,7 +11,35 @@ import requests
 
 import cognitive_face as CF
 
-_BASE_URL = 'https://westus.api.cognitive.microsoft.com/face/v1.0/'
+
+class Region(object):
+    """Manage API region"""
+
+    @classmethod
+    def set(cls, region):
+        """Set the API region"""
+        cls.region = region
+
+    @classmethod
+    def get(cls):
+        """Get the API region"""
+        if not hasattr(cls, 'region'):
+            cls.region = 'uswest'
+        return cls.region
+
+
+class BaseUrl(object):
+
+    @classmethod
+    def set(cls, url):
+        cls.url = url
+
+    @classmethod
+    def get(cls):
+        if not hasattr(cls, 'url'):
+            cls.url = 'https://' + Region.get() + '.api.cognitive.microsoft.com/face/v1.0/'
+        return cls.url
+
 TIME_SLEEP = 1
 
 
@@ -58,9 +86,9 @@ def request(method, url, data=None, json=None, headers=None, params=None):
     # pylint: disable=too-many-arguments
     """Universal interface for request."""
 
-    # Make it possible to call only with short name (without _BASE_URL).
+    # Make it possible to call only with short name (without BaseUrl).
     if not url.startswith('https://'):
-        url = _BASE_URL + url
+        url = BaseUrl.get() + url
 
     # Setup the headers with default Content-Type and Subscription Key.
     headers = headers or {}
@@ -87,7 +115,7 @@ def request(method, url, data=None, json=None, headers=None, params=None):
             error_msg.get('code'),
             error_msg.get('message'))
 
-    # Prevent `reponse.json()` complains about empty response.
+    # Prevent `response.json()` complains about empty response.
     if response.text:
         result = response.json()
     else:
@@ -117,7 +145,7 @@ def parse_image(image):
         headers = {'Content-Type': 'application/octet-stream'}
         data = open(image, 'rb').read()
         return headers, data, None
-    else:  # Defailt treat it as a URL (string).
+    else:  # Default treat it as a URL (string).
         headers = {'Content-Type': 'application/json'}
         json = {'url': image}
         return headers, None, json

--- a/cognitive_face/util.py
+++ b/cognitive_face/util.py
@@ -11,34 +11,19 @@ import requests
 
 import cognitive_face as CF
 
-
-class Region(object):
-    """Manage API region"""
-
-    @classmethod
-    def set(cls, region):
-        """Set the API region"""
-        cls.region = region
-
-    @classmethod
-    def get(cls):
-        """Get the API region"""
-        if not hasattr(cls, 'region'):
-            cls.region = 'uswest'
-        return cls.region
-
+DEFAULT_BASE_URL = 'https://westus.api.cognitive.microsoft.com/face/v1.0/'
 
 class BaseUrl(object):
 
     @classmethod
-    def set(cls, url):
-        cls.url = url
+    def set(cls, base_url):
+        cls.base_url = base_url
 
     @classmethod
     def get(cls):
-        if not hasattr(cls, 'url'):
-            cls.url = 'https://' + Region.get() + '.api.cognitive.microsoft.com/face/v1.0/'
-        return cls.url
+        if not hasattr(cls, 'base_url'):
+            cls.base_url = DEFAULT_BASE_URL
+        return cls.base_url
 
 TIME_SLEEP = 1
 


### PR DESCRIPTION
# What did you implement:

Addressed #31 and #29 

# How did you implement it:

- Created 2 new classes: Region and BaseUrl following the Key class template
- BaseUrl will use Region.get() and Region was exposed and totally configurable.
- Default region is set to 'westus' to avoid any disruption to existing code bases.
- Added REGION config template to `/cognitive_face/tests/config.sample.py`
- Fixed some existing typos

# How can we verify it:

I have modified the test suit appropriately.

Just run `python setup.py test`

# Todos:

 - [X] Write tests
 - [X] Write documentation
 - [X] Fix linting errors
 - [X] Make sure code coverage hasn't dropped
 - [X] Provide verification config/commands/resources
 - [X] Change ready for review message below
 

**Is this ready for review?:** YES

**Is it a breaking change?:** NO