### PR TITLE
Fixed base url if no trailing slash

### DIFF
--- a/cognitive_face/util.py
+++ b/cognitive_face/util.py
@@ -58,7 +58,7 @@ class Key(object):
 class BaseUrl(object):
     @classmethod
     def set(cls, base_url):
-        cls.base_url = base_url
+        cls.base_url = base_url if base_url.endswith('/') else base_url + '/'
 
     @classmethod
     def get(cls):


### PR DESCRIPTION
By default, Azure dashboard gives the base url without a trailing slash.  So if a user copy and pastes the url, the sdk will give you a unhelpful error of "Resource Not Found".

The commit coalesces the base url to always have a trailing slash