### PR TITLE
Additional args needed for wx.GridSizer if wxPython 4 is used

### DIFF
--- a/sample/view/panel_subscription.py
+++ b/sample/view/panel_subscription.py
@@ -39,7 +39,7 @@ class SubscriptionPanel(MyPanel):
         self.link.SetBackgroundColour(colour_window)
         self.sizer.Add(self.link, flag=flag, border=5)
 
-        subgridsizer = wx.GridSizer(rows=2, cols=2)
+        subgridsizer = wx.GridSizer(rows=2, cols=2, hgap=5, vgap=5)
 
         flag = wx.ALIGN_CENTER_VERTICAL | wx.ALL | wx.FIXED_MINSIZE
         label = 'Subscription Key : '


### PR DESCRIPTION
This line change would provide support for wxPython 4 (albeit still in beta).  Merge if you think this will help.  Note, it may break wxPython 3 support, but I don't actually see wxPython available from PyPi for versions other than 4.  Hence this PR.

GridSizer needs extra arguments to work with the latest wxPython package (v4.0.0b2).  These additional arguments provide vertical and horizontal gap of white space.