### PR TITLE
Adding Content-Type Options to Detect

### DIFF
--- a/cognitive_face/face.py
+++ b/cognitive_face/face.py
@@ -7,7 +7,7 @@ Description: Face section of the Cognitive Face API.
 from . import util
 
 
-def detect(image, face_id=True, landmarks=False, attributes=''):
+def detect(image, face_id=True, landmarks=False, attributes='', content_type='application/json'):
     """Detect human faces in an image and returns face locations, and
     optionally with `face_id`s, landmarks, and attributes.
 
@@ -30,6 +30,8 @@ def detect(image, face_id=True, landmarks=False, attributes=''):
         contain the corresponding values depending on input parameters.
     """
     url = 'detect'
+    
+    headers["content-type"] = content_type
     headers, data, json = util.parse_image(image)
     params = {
         'returnFaceId': face_id and 'true' or 'false',

--- a/cognitive_face/face.py
+++ b/cognitive_face/face.py
@@ -30,7 +30,7 @@ def detect(image, face_id=True, landmarks=False, attributes='', content_type='ap
         contain the corresponding values depending on input parameters.
     """
     url = 'detect'
-    headers["content-type"] = content_type
+    headers['content-type'] = content_type
     headers, data, json = util.parse_image(image)
     params = {
         'returnFaceId': face_id and 'true' or 'false',

--- a/cognitive_face/face.py
+++ b/cognitive_face/face.py
@@ -30,7 +30,6 @@ def detect(image, face_id=True, landmarks=False, attributes='', content_type='ap
         contain the corresponding values depending on input parameters.
     """
     url = 'detect'
-    
     headers["content-type"] = content_type
     headers, data, json = util.parse_image(image)
     params = {

--- a/cognitive_face/util.py
+++ b/cognitive_face/util.py
@@ -18,7 +18,6 @@ TIME_SLEEP = 1
 
 class CognitiveFaceException(Exception):
     """Custom Exception for the python SDK of the Cognitive Face API.
-
     Attributes:
         status_code: HTTP response status code.
         code: error code.
@@ -82,7 +81,12 @@ def request(method, url, data=None, json=None, headers=None, params=None):
     if 'Content-Type' not in headers:
         headers['Content-Type'] = 'application/json'
     headers['Ocp-Apim-Subscription-Key'] = Key.get()
-
+    
+    # Check that the content-type is valid
+    if headers['content-type'] not 'application/json':
+        if headers ['content-type'] not 'application/octet-stream':
+            raise ValueError('Invalid request body type:' + headers['Content-Type'])
+            
     response = requests.request(
         method,
         url,
@@ -116,13 +120,10 @@ def request(method, url, data=None, json=None, headers=None, params=None):
 
 def parse_image(image):
     """Parse the image smartly and return metadata for request.
-
     First check whether the image is a URL or a file path or a file-like object
     and return corresponding metadata.
-
     Args:
         image: A URL or a file path or a file-like object represents an image.
-
     Returns:
         a three-item tuple consist of HTTP headers, binary data and json data
         for POST.


### PR DESCRIPTION
This change would allow the the detect function call to take a base64 encoded image as supported by the API. This change also protects the request function call by verifying that the 'Content-Type' parameter is valid.