### PR TITLE
Python3.7

### DIFF
--- a/sample/util.py
+++ b/sample/util.py
@@ -175,7 +175,7 @@ def key_with_max_value(item):
     return max(item.items(), key=operator.itemgetter(1))[0]
 
 
-def async(func):
+async def func()::
     """Async wrapper."""
 
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
Update/Patch to the sample/util.py to support Python 3.7. currently unable to run samples on Python 3.7 


 File "sample\util.py", line 178
    def async(func):
            ^
SyntaxError: invalid syntax