### PR TITLE
Add type bytes, then You can read image file by yourself.

### DIFF
--- a/cognitive_face/util.py
+++ b/cognitive_face/util.py
@@ -134,6 +134,10 @@ def parse_image(image):
         headers = {'Content-Type': 'application/octet-stream'}
         data = open(image, 'rb').read()
         return headers, data, None
+    elif type(image) == bytes:   # You can read image file by yourself.
+        headers = {'Content-Type': 'application/octet-stream'}
+        data = image
+        return headers, data, None
     else:  # Default treat it as a URL (string).
         headers = {'Content-Type': 'application/json'}
         json = {'url': image}


### PR DESCRIPTION
I add a type bytes, then user can read file by itself.
For example, I use opencv to capture image from ipcam, then change it type from ndarray to bytes.

    I = ipcam.getframe()
    I = cv2.resize(I, (720, 480))
    Ibyte = cv2.imencode(".jpg", I)[1].tostring()
