### PR TITLE
Added face recognition API handler for bytes object to help enable DB…

### DIFF
--- a/cognitive_face/util.py
+++ b/cognitive_face/util.py
@@ -120,13 +120,17 @@ def parse_image(image):
     and return corresponding metadata.
 
     Args:
-        image: A URL or a file path or a file-like object represents an image.
+        image: A bytes object, URL, file path or a file-like object representing an image.
 
     Returns:
         a three-item tuple consist of HTTP headers, binary data and json data
         for POST.
     """
-    if hasattr(image, 'read'):  # When image is a file-like object.
+    if hasattr(image, 'decode'): #When image is a bytes object
+        headers = {'Content-Type': 'application/octet-stream'}
+        data = image
+        return headers, data, None
+    elif hasattr(image, 'read'):  # When image is a file-like object.
         headers = {'Content-Type': 'application/octet-stream'}
         data = image.read()
         return headers, data, None


### PR DESCRIPTION
Currently it is cumbersome to supply images to the recognition system when they are stored in-memory in bytes objects rather then remote links or files on disk. This is problematic as bytes objects are typical when the image is stored on Azure Storage (in the blob store) or CosmosDB.

Added an additional handler to the facial recognition parser which allows it to recognize and submit bytes objects